### PR TITLE
Implement task progress actions

### DIFF
--- a/app/api/community/[communityId]/projects/[projectId]/tasks/[taskId]/approve/route.ts
+++ b/app/api/community/[communityId]/projects/[projectId]/tasks/[taskId]/approve/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { prisma, safeJson } from "@/lib/prisma";
+import { MemberRole } from "@prisma/client";
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ communityId: string; projectId: string; taskId: string }> }
+) {
+  const { communityId, projectId, taskId } = await ctx.params;
+
+  try {
+    const { address } = await req.json();
+    if (!address) {
+      return NextResponse.json({ error: "Missing address" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { address },
+      select: { id: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const member = await prisma.member.findFirst({
+      where: { userId: user.id, communityId },
+      select: { id: true, role: true },
+    });
+    if (!member) {
+      return NextResponse.json({ error: "Not a community member" }, { status: 403 });
+    }
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { teamLeaderId: true },
+    });
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const isLeader = member.id === project.teamLeaderId;
+    const isProfessor = member.role === MemberRole.Professor || member.role === MemberRole.Owner;
+
+    if (!isLeader && !isProfessor) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    const task = await prisma.task.findFirst({
+      where: { id: taskId, projectId },
+      select: { status: true, balance: true, members: { select: { id: true } } },
+    });
+    if (!task) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+    if (task.status !== "under_review") {
+      return NextResponse.json({ error: "Task not ready" }, { status: 400 });
+    }
+
+    const total = BigInt(task.balance);
+    const count = task.members.length;
+    const share = count ? total / BigInt(count) : 0n;
+    const extra = count ? total % BigInt(count) : 0n;
+
+    const ops: any[] = [];
+    task.members.forEach((m, idx) => {
+      let inc = share;
+      if (idx < Number(extra)) inc += 1n;
+      if (inc > 0n) {
+        ops.push(
+          prisma.member.update({
+            where: { id: m.id },
+            data: { balance: { increment: inc.toString() } },
+          })
+        );
+      }
+    });
+
+    ops.unshift(
+      prisma.task.update({
+        where: { id: taskId },
+        data: { status: "completed", balance: "0" },
+      })
+    );
+
+    const [updated] = await prisma.$transaction(ops);
+
+    return NextResponse.json(safeJson(updated), { status: 200 });
+  } catch (err) {
+    console.error("approve-task error", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/community/[communityId]/projects/[projectId]/tasks/[taskId]/finish/route.ts
+++ b/app/api/community/[communityId]/projects/[projectId]/tasks/[taskId]/finish/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { prisma, safeJson } from "@/lib/prisma";
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ communityId: string; projectId: string; taskId: string }> }
+) {
+  const { communityId, projectId, taskId } = await ctx.params;
+
+  try {
+    const { address } = await req.json();
+    if (!address) {
+      return NextResponse.json({ error: "Missing address" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { address },
+      select: { id: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const member = await prisma.member.findFirst({
+      where: { userId: user.id, communityId },
+      select: { id: true },
+    });
+    if (!member) {
+      return NextResponse.json({ error: "Not a community member" }, { status: 403 });
+    }
+
+    const task = await prisma.task.findFirst({
+      where: { id: taskId, projectId },
+      select: { status: true, members: { select: { id: true } } },
+    });
+    if (!task) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+    if (task.status !== "in_progress") {
+      return NextResponse.json({ error: "Cannot finish task" }, { status: 400 });
+    }
+
+    const assigned = task.members.some((m) => m.id === member.id);
+    if (!assigned) {
+      return NextResponse.json({ error: "Not assigned to task" }, { status: 403 });
+    }
+
+    const updated = await prisma.task.update({
+      where: { id: taskId },
+      data: { status: "under_review" },
+    });
+
+    return NextResponse.json(safeJson(updated), { status: 200 });
+  } catch (err) {
+    console.error("finish-task error", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/community/[communityId]/projects/[projectId]/tasks/[taskId]/start/route.ts
+++ b/app/api/community/[communityId]/projects/[projectId]/tasks/[taskId]/start/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { prisma, safeJson } from "@/lib/prisma";
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ communityId: string; projectId: string; taskId: string }> }
+) {
+  const { communityId, projectId, taskId } = await ctx.params;
+
+  try {
+    const { address } = await req.json();
+    if (!address) {
+      return NextResponse.json({ error: "Missing address" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { address },
+      select: { id: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const member = await prisma.member.findFirst({
+      where: { userId: user.id, communityId },
+      select: { id: true },
+    });
+    if (!member) {
+      return NextResponse.json({ error: "Not a community member" }, { status: 403 });
+    }
+
+    const task = await prisma.task.findFirst({
+      where: { id: taskId, projectId },
+      select: { status: true, members: { select: { id: true } } },
+    });
+    if (!task) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+    if (task.status !== "not_started") {
+      return NextResponse.json({ error: "Cannot start task" }, { status: 400 });
+    }
+
+    const assigned = task.members.some((m) => m.id === member.id);
+    if (!assigned) {
+      return NextResponse.json({ error: "Not assigned to task" }, { status: 403 });
+    }
+
+    const updated = await prisma.task.update({
+      where: { id: taskId },
+      data: { status: "in_progress" },
+    });
+
+    return NextResponse.json(safeJson(updated), { status: 200 });
+  } catch (err) {
+    console.error("start-task error", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/components/project/task-details.tsx
+++ b/components/project/task-details.tsx
@@ -57,11 +57,6 @@ export function TaskDetails({ task }: TaskDetailsProps) {
   const { address: currentAddress } = useAccount();
   const router = useRouter();
 
-  const [localTask, setLocalTask] = useState<TaskDetailsProps["task"]>(task);
-
-  useEffect(() => {
-    setLocalTask(task);
-  }, [task]);
 
   const [role, setRole] = useState<string | null>(null);
   const [meId, setMeId] = useState<string | null>(null);
@@ -109,11 +104,11 @@ export function TaskDetails({ task }: TaskDetailsProps) {
   // share helper
   const [copied, setCopied] = useState(false);
   const share = async () => {
-    const href = `/${communityId}/projects/${projectId}?task=${localTask.id}`;
+    const href = `/${communityId}/projects/${projectId}?task=${task.id}`;
     const url = window.location.origin + href;
     try {
       if (navigator.share) {
-        await navigator.share({ title: localTask.name, url });
+        await navigator.share({ title: task.name, url });
       } else {
         await navigator.clipboard.writeText(url);
         setCopied(true);
@@ -122,24 +117,24 @@ export function TaskDetails({ task }: TaskDetailsProps) {
     } catch {}
   };
 
-  const creatorName = localTask.creator.name ?? localTask.creator.address;
+  const creatorName = task.creator.name ?? task.creator.address;
   const creatorInitials = creatorName
     .split(" ")
     .map((w) => w[0])
     .join("")
     .toUpperCase();
 
-  const isAssigned = localTask.members.some(
+  const isAssigned = task.members.some(
     (m) => m.address.toLowerCase() === currentAddress?.toLowerCase()
   );
 
   const canApprove =
-    localTask.status === "under_review" &&
+    task.status === "under_review" &&
     (role === "Professor" || role === "Owner" || meId === projTeamLeaderId);
 
   const startTask = async () => {
     const res = await fetch(
-      `/api/community/${communityId}/projects/${projectId}/tasks/${localTask.id}/start`,
+      `/api/community/${communityId}/projects/${projectId}/tasks/${task.id}/start`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -147,14 +142,13 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       }
     );
     if (res.ok) {
-      const updated = await res.json();
-      setLocalTask(updated);
+      router.refresh();
     }
   };
 
   const finishTask = async () => {
     const res = await fetch(
-      `/api/community/${communityId}/projects/${projectId}/tasks/${localTask.id}/finish`,
+      `/api/community/${communityId}/projects/${projectId}/tasks/${task.id}/finish`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -162,14 +156,13 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       }
     );
     if (res.ok) {
-      const updated = await res.json();
-      setLocalTask(updated);
+      router.refresh();
     }
   };
 
   const approveTask = async () => {
     const res = await fetch(
-      `/api/community/${communityId}/projects/${projectId}/tasks/${localTask.id}/approve`,
+      `/api/community/${communityId}/projects/${projectId}/tasks/${task.id}/approve`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -177,8 +170,7 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       }
     );
     if (res.ok) {
-      const updated = await res.json();
-      setLocalTask(updated);
+      router.refresh();
     }
   };
 
@@ -205,7 +197,7 @@ export function TaskDetails({ task }: TaskDetailsProps) {
             <DropdownMenuItem
                 onClick={() =>
                   router.push(
-                    `/${communityId}/projects/${projectId}/tasks/${localTask.id}/edit`
+                    `/${communityId}/projects/${projectId}/tasks/${task.id}/edit`
                   )
                 }
             >
@@ -217,9 +209,9 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       )}
 
       <CardHeader>
-        <CardTitle>{localTask.name}</CardTitle>
-        {localTask.description && (
-          <CardDescription>{localTask.description}</CardDescription>
+        <CardTitle>{task.name}</CardTitle>
+        {task.description && (
+          <CardDescription>{task.description}</CardDescription>
         )}
       </CardHeader>
 
@@ -230,31 +222,31 @@ export function TaskDetails({ task }: TaskDetailsProps) {
             <p className="text-xs text-muted-foreground">Status</p>
             <Badge
               variant={
-                localTask.status === "completed"
+                task.status === "completed"
                   ? "success"
-                  : localTask.status === "under_review"
+                  : task.status === "under_review"
                   ? "outline"
-                  : localTask.status === "in_progress"
+                  : task.status === "in_progress"
                   ? "secondary"
                   : "destructive"
               }
             >
-              {localTask.status.replace("_", " ")}
+              {task.status.replace("_", " ")}
             </Badge>
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Priority</p>
             <Badge
               variant={
-                localTask.priority === "high"
+                task.priority === "high"
                   ? "destructive"
-                  : localTask.priority === "medium"
+                  : task.priority === "medium"
                   ? "warning"
                   : "default"
               }
             >
-              {localTask.priority.charAt(0).toUpperCase() +
-                localTask.priority.slice(1)}
+              {task.priority.charAt(0).toUpperCase() +
+                task.priority.slice(1)}
             </Badge>
           </div>
         </div>
@@ -264,13 +256,13 @@ export function TaskDetails({ task }: TaskDetailsProps) {
           <div>
             <p className="text-xs text-muted-foreground">Budget</p>
             <p className="font-medium">
-              {localTask.balance.toString()} TOKEN
+              {task.balance.toString()} TOKEN
             </p>
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Deadline</p>
             <p className="font-medium">
-              {new Date(localTask.deadline).toLocaleDateString()}
+              {new Date(task.deadline).toLocaleDateString()}
             </p>
           </div>
         </div>
@@ -295,7 +287,7 @@ export function TaskDetails({ task }: TaskDetailsProps) {
             Assigned to
           </p>
           <div className="flex -space-x-2">
-            {localTask.members.map((m) => {
+            {task.members.map((m) => {
               const name = m.name ?? m.address;
               const initials = name
                 .split(" ")
@@ -316,10 +308,10 @@ export function TaskDetails({ task }: TaskDetailsProps) {
         </div>
 
         {/* Action Button */}
-        {isAssigned && localTask.status === "not_started" && (
+        {isAssigned && task.status === "not_started" && (
           <Button onClick={startTask}>Start Task</Button>
         )}
-        {isAssigned && localTask.status === "in_progress" && (
+        {isAssigned && task.status === "in_progress" && (
           <Button onClick={finishTask}>Finish Task</Button>
         )}
         {canApprove && (

--- a/components/project/task-details.tsx
+++ b/components/project/task-details.tsx
@@ -123,6 +123,50 @@ export function TaskDetails({ task }: TaskDetailsProps) {
     .join("")
     .toUpperCase();
 
+  const isAssigned = task.members.some(
+    (m) => m.address.toLowerCase() === currentAddress?.toLowerCase()
+  );
+
+  const canApprove =
+    task.status === "under_review" &&
+    (role === "Professor" || role === "Owner" || meId === projTeamLeaderId);
+
+  const startTask = async () => {
+    await fetch(
+      `/api/community/${communityId}/projects/${projectId}/tasks/${task.id}/start`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address: currentAddress }),
+      }
+    );
+    router.refresh();
+  };
+
+  const finishTask = async () => {
+    await fetch(
+      `/api/community/${communityId}/projects/${projectId}/tasks/${task.id}/finish`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address: currentAddress }),
+      }
+    );
+    router.refresh();
+  };
+
+  const approveTask = async () => {
+    await fetch(
+      `/api/community/${communityId}/projects/${projectId}/tasks/${task.id}/approve`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address: currentAddress }),
+      }
+    );
+    router.refresh();
+  };
+
   return (
     <Card className="relative">
       {/* 3-dots menu */}
@@ -255,6 +299,17 @@ export function TaskDetails({ task }: TaskDetailsProps) {
             })}
           </div>
         </div>
+
+        {/* Action Button */}
+        {isAssigned && task.status === "not_started" && (
+          <Button onClick={startTask}>Start Task</Button>
+        )}
+        {isAssigned && task.status === "in_progress" && (
+          <Button onClick={finishTask}>Finish Task</Button>
+        )}
+        {canApprove && (
+          <Button onClick={approveTask}>Approve</Button>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- allow task assignees to start and finish their tasks
- add approve action for professors or team leaders
- create API routes for starting, finishing and approving tasks
- display start/finish/approve buttons in task details

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c36fa67d883218d44144b0bdb6477