### PR TITLE
Fix task UI refresh & show user balance

### DIFF
--- a/app/(app)/(dapp)/[communityId]/dashboard/_components/stat-cards.tsx
+++ b/app/(app)/(dapp)/[communityId]/dashboard/_components/stat-cards.tsx
@@ -1,21 +1,23 @@
 
 "use client";
 
-import { Wallet, Users2, ClipboardList, FolderGit2 } from "lucide-react";
+import { Wallet, Users2, ClipboardList, FolderGit2, Coins } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default function StatCards(props: {
   balance: string;
+  allocation: string;
   members: number;
   projects: number;
   tasks: number;
 }) {
-  const { balance, members, projects, tasks } = props;
+  const { balance, allocation, members, projects, tasks } = props;
   const stats = [
-    { label: "Treasury", val: `${balance} TOKEN`, icon: Wallet },
-    { label: "Members",  val: members,           icon: Users2 },
-    { label: "Projects", val: projects,          icon: FolderGit2 },
-    { label: "Tasks",    val: tasks,             icon: ClipboardList },
+    { label: "Balance",    val: `${balance} TOKEN`,    icon: Wallet },
+    { label: "Allocation", val: `${allocation} TOKEN`, icon: Coins },
+    { label: "Members",    val: members,              icon: Users2 },
+    { label: "Projects",   val: projects,             icon: FolderGit2 },
+    { label: "Tasks",      val: tasks,                icon: ClipboardList },
   ];
 
   return (

--- a/app/(app)/(dapp)/[communityId]/layout.js
+++ b/app/(app)/(dapp)/[communityId]/layout.js
@@ -62,7 +62,7 @@ export default function DappLayout({ children }) {
           </div>
           <div className="flex items-center gap-2">
             <ModeToggle />
-            <MiniBalance />
+            <MiniBalance communityId={communityId} />
             <WalletButton />
           </div>
         </header>

--- a/app/(app)/(dapp)/[communityId]/projects/[projectId]/project.tsx
+++ b/app/(app)/(dapp)/[communityId]/projects/[projectId]/project.tsx
@@ -68,7 +68,10 @@ export default function ProjectPage() {
       })
       .then((data: Project) => {
         setProject(data);
-        if (data.tasks.length) setSelected(data.tasks[0]);
+        setSelected((prev) => {
+          if (!prev) return data.tasks[0] ?? null;
+          return data.tasks.find((t) => t.id === prev.id) ?? data.tasks[0] ?? null;
+        });
       })
       .catch((err) => setError(err.message));
   };
@@ -112,7 +115,7 @@ export default function ProjectPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <TasksTable tasks={project.tasks} onSelect={setSelected} />
-        {selectedTask && <TaskDetails task={selectedTask} />}
+        {selectedTask && <TaskDetails task={selectedTask} refresh={refresh} />}
       </div>
 
       <Dialog open={open} onOpenChange={setOpen}>

--- a/components/MiniBalance.js
+++ b/components/MiniBalance.js
@@ -1,36 +1,50 @@
 "use client";
 
 import { RiCopperCoinLine } from "react-icons/ri";
-import { useAccount, useReadContract } from 'wagmi';
-import { BBLTOKEN_CONTRACT, BBLTOKEN_ABI } from '@/contracts/BBLToken';
-import { useEffect, useState } from 'react';
-import { formatUnits } from "viem";
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
-export default function MiniBalance() {
-    const { address } = useAccount();
-    const [balance, setBalance] = useState('0.00');
+export default function MiniBalance({ communityId }) {
+  const { address } = useAccount();
+  const [balance, setBalance] = useState("0");
+  const [allocation, setAllocation] = useState("0");
 
-    const result = useReadContract({
-        address: BBLTOKEN_CONTRACT,
-        abi: BBLTOKEN_ABI,
-        functionName: 'balanceOf',
-        args: [address],
-        enabled: !!address,
-    });
-
-    useEffect(() => {
-        if (result) {
-            console.log('result', result.data);
-            const bal = result.data ? formatUnits(result.data, 6) : '0.00';
-            console.log('bal', bal);
-            setBalance(bal);
+  useEffect(() => {
+    if (!communityId || !address) return;
+    fetch(`/api/community/${communityId}/members`)
+      .then((r) => r.json())
+      .then((members) => {
+        const me = members.find(
+          (m) => m.user.address.toLowerCase() === address.toLowerCase()
+        );
+        if (me) {
+          setBalance(me.balance.toString());
+          setAllocation(me.allocation.toString());
         }
-    }, [result]);
+      })
+      .catch(console.error);
+  }, [communityId, address]);
 
-    return (
-        <div className='flex items-center justify-center space-x-1 bg-primary py-2 pl-2 pr-3 rounded-xl text-sm'>
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center justify-center space-x-1 bg-primary py-2 pl-2 pr-3 rounded-xl text-sm cursor-default">
             <RiCopperCoinLine size={20} />
-            <h1 className='font-bold'>{balance} BBL</h1>
-        </div>
-    );
+            <h1 className="font-bold">{balance} BBL</h1>
+            <span className="text-xs text-primary-foreground/70">/ {allocation}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          Available / allocated tokens
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
 }

--- a/components/project/task-details.tsx
+++ b/components/project/task-details.tsx
@@ -47,9 +47,10 @@ interface TaskDetailsProps {
     creator: User;
     members: User[];
   };
+  refresh: () => void;
 }
 
-export function TaskDetails({ task }: TaskDetailsProps) {
+export function TaskDetails({ task, refresh }: TaskDetailsProps) {
   const { communityId, projectId } = useParams<{
     communityId: string;
     projectId: string;
@@ -142,7 +143,7 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       }
     );
     if (res.ok) {
-      router.refresh();
+      refresh();
     }
   };
 
@@ -156,7 +157,7 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       }
     );
     if (res.ok) {
-      router.refresh();
+      refresh();
     }
   };
 
@@ -170,7 +171,7 @@ export function TaskDetails({ task }: TaskDetailsProps) {
       }
     );
     if (res.ok) {
-      router.refresh();
+      refresh();
     }
   };
 


### PR DESCRIPTION
## Summary
- refresh project data when updating task status
- display user token balance and allocation
- show user stats on dashboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4211eee08321a60508fc498f2e8c